### PR TITLE
Inversion

### DIFF
--- a/cur-lib/cur/ntac/inversion.rkt
+++ b/cur-lib/cur/ntac/inversion.rkt
@@ -1,0 +1,134 @@
+#lang s-exp "../main.rkt"
+(provide
+ (for-syntax
+  by-inversion*
+  inversion*))
+
+(require
+ "../stdlib/prop.rkt" ; for False (see inversion), And (rewrite)
+ "../stdlib/sugar.rkt"
+ "../stdlib/equality.rkt"
+ "base.rkt"
+ "standard.rkt"
+  (for-syntax "ctx.rkt" "utils.rkt"
+              (only-in macrotypes/typecheck-core subst substs)
+              macrotypes/stx-utils
+              racket/list
+              racket/match
+              racket/pretty
+              syntax/stx
+              (for-syntax racket/base syntax/parse)))
+
+
+(begin-for-syntax
+
+  (define-syntax (by-inversion* syn)
+    (syntax-parse syn
+      [(_ H) #'(fill (inversion* #'H))]
+      [(_ H #:as namess) #'(fill (inversion* #'H #'namess))]))
+
+  (define ((inversion* name [new-xss_ #f]) ctxt pt)
+    (match-define (ntt-hole _ goal) pt)
+
+    (define name-ty (ctx-lookup ctxt name))
+
+    ;; get info about the datatype and its constructors
+    ;; A = params
+    ;; i = indices
+    ;; x = non-recursive args to constructors
+    ;; xrec = recrusive args to constructors
+    ;; irec = indices to recursive args
+    (define/syntax-parse
+      (elim-TY ([A τA] ...)
+               ([i τi] ...)
+               Cinfo ...)
+      (get-match-info name-ty))
+
+    (define num-params
+      (stx-length #'(A ...)))
+
+    (define get-idxs
+      (if (stx-null? #'(i ...))
+        (λ (t) null)
+        (λ (t) (stx-drop t (add1 num-params)))))
+
+    (define new-xss
+      (or new-xss_
+          (stx-map (λ (_) #f) #'(Cinfo ...))))
+
+    ;; infer from name-ty: params (Aval ...) and indices (ival ...)
+
+    (define/syntax-parse ((Aval ...) (ival ...))
+      (syntax-parse name-ty
+        [((~literal #%plain-app) _ . name-ty-args)
+         (stx-split-at #'name-ty-args num-params)]))
+
+    ;; generate names for the equality hypothesis we will introduce
+
+    (define/syntax-parse (eq-name ...)
+      ((freshens name) (stx-map (λ (x) (format-id x "Heq~a" x))
+                                #'(i ...))))
+
+    ;; generate subgoals for each data constructor case
+
+    (define-values [subgoals mk-elim-methods]
+      (for/lists (subgoals mk-elim-methods)
+                 ([Cinfo (in-stx-list #'(Cinfo ...))]
+                  [new-xs (in-stx-list new-xss)])
+        (syntax-parse Cinfo
+          [[C ([x_ τx_] ... τout_)
+              ([xrec_ . _] ...)]
+           #:with (new-x ...) (or new-xs ((freshens name) #'(x_ ...)))
+           #:with (xrec ...) ((freshens name) #'(xrec_ ...))
+           #:with (τx ... τout) (substs #'(Aval ... new-x ...)
+                                        #'(A    ... x_ ...)
+                                        #'(τx_ ... τout_))
+
+           ;; (eq ...) = equality types for the indices of this particular constructor
+           #:with (iout ...) (get-idxs #'τout)
+           #:with (eq ...) #'[(== τi ival iout) ...]
+
+           #:do [(define (update-ctxt/xs ctxt)
+                   (for/fold ([ctxt ctxt])
+                             ([new-x (in-stx-list #'(new-x ...))]
+                              [τx    (in-stx-list #'(τx ...))])
+                     (ctx-add ctxt new-x (normalize τx ctxt))))
+                 ; NOTE: xrec purposely not put in context; the user doesn't need it.
+                 ; maybe should've used dependent matching instead of elim?
+                 (define (update-ctxt/eqs ctxt)
+                   (ctx-adds ctxt
+                             #'(eq-name ...)
+                             (stx-map (normalize/ctxt ctxt) #'(eq ...))))
+                 (define update-ctxt
+                   (compose update-ctxt/eqs
+                            update-ctxt/xs))]
+
+           (values
+            (make-ntt-context ; subgoal
+             update-ctxt
+             (make-ntt-hole goal))
+            (λ (pf)
+              #`(λ new-x ... xrec ... eq-name ...
+                   #,pf)))])))
+
+    (make-ntt-apply
+     goal
+     subgoals
+     (λ pfs ;; constructs proof term, from each subgoals' proof terms
+       (quasisyntax/loc goal
+         ((new-elim
+           ; target
+           #,name
+           ; motive
+           #,(with-syntax ([(i* ...) (generate-temporaries #'(ival ...))])
+               (with-syntax ([(eq ...) (stx-map unexpand #'[(== τi ival i*) ...])])
+                 #`(λ i* ... #,name
+                      (-> eq ...
+                          #,goal))))
+           ; methods
+           . #,(map (λ (mk pf) (mk pf)) mk-elim-methods pfs))
+          ; arguments (refl proofs)
+          (refl τi ival)
+          ...)))))
+
+  )

--- a/cur-lib/cur/ntac/inversion.rkt
+++ b/cur-lib/cur/ntac/inversion.rkt
@@ -94,7 +94,7 @@
 
            #:with (iout ...) (map (normalize/ctxt ctxt+xs) (get-idxs #'τout))
            #:with (==-id ...) (stx-map (λ (_) (generate-temporary 'eq)) #'(i ...))
-           #:with (==-ty ...) #'[(== ival iout) ...]
+           #:with (==-ty ...) #'[(== iout ival) ...]
 
            #;
            #:do #;[(printf "** ~s\n** ~s\n** ~s\n------------\n"
@@ -103,8 +103,8 @@
                          (map syntax->datum (attribute ==-id)))]
 
            ; Unify the provided indices (ival) with the constructor's indices (iout)
-           (match (prove-unifys (attribute ival)
-                                (attribute iout)
+           (match (prove-unifys (attribute iout)
+                                (attribute ival)
                                 (attribute ==-id))
              ; Add derived equalities to context and make subgoal
              [(derived ==s ==-pfs)
@@ -142,7 +142,7 @@
            #,name
            ; motive
            #,(with-syntax ([(i* ...) (generate-temporaries #'(i ...))])
-               (with-syntax ([(==-ty ...) (stx-map unexpand #'((== ival i*) ...))])
+               (with-syntax ([(==-ty ...) (stx-map unexpand #'((== i* ival) ...))])
                  #`(λ i* ... #,name
                       (-> ==-ty ... #,(unexpand goal)))))
            ; methods

--- a/cur-lib/cur/ntac/inversion.rkt
+++ b/cur-lib/cur/ntac/inversion.rkt
@@ -26,7 +26,8 @@
   (define-syntax (by-inversion* syn)
     (syntax-parse syn
       [(_ H) #'(fill (inversion* #'H))]
-      [(_ H #:as namess) #'(fill (inversion* #'H #'namess))]))
+      [(_ H #:as name:id ...) #'(fill (inversion* #'H #'[(name ...)]))]
+      [(_ H #:as (names ...)) #'(fill (inversion* #'H #'(names ...)))]))
 
   (define ((inversion* name [new-xss_ #f]) ctxt pt)
     (match-define (ntt-hole _ goal) pt)

--- a/cur-lib/cur/ntac/inversion.rkt
+++ b/cur-lib/cur/ntac/inversion.rkt
@@ -1,8 +1,5 @@
 #lang s-exp "../main.rkt"
-(provide
- (for-syntax
-  by-inversion*
-  inversion*))
+(provide (for-syntax by-inversion inversion))
 
 (require
  "../stdlib/prop.rkt" ; for False (see inversion), And (rewrite)
@@ -23,13 +20,13 @@
 
 (begin-for-syntax
 
-  (define-syntax (by-inversion* syn)
+  (define-syntax (by-inversion syn)
     (syntax-parse syn
-      [(_ H) #'(fill (inversion* #'H))]
-      [(_ H #:as name:id ...) #'(fill (inversion* #'H #'[(name ...)]))]
-      [(_ H #:as (names ...)) #'(fill (inversion* #'H #'(names ...)))]))
+      [(_ H) #'(fill (inversion #'H))]
+      [(_ H #:as name:id ...) #'(fill (inversion #'H #'[(name ...)]))]
+      [(_ H #:as (names ...)) #'(fill (inversion #'H #'(names ...)))]))
 
-  (define ((inversion* name [new-xss_ #f]) ctxt pt)
+  (define ((inversion name [new-xss_ #f]) ctxt pt)
     (match-define (ntt-hole _ goal) pt)
     (define name-ty (or (ctx-lookup ctxt name) ; thm in ctx
                         (typeof (expand/df name))))

--- a/cur-lib/cur/ntac/inversion.rkt
+++ b/cur-lib/cur/ntac/inversion.rkt
@@ -120,11 +120,13 @@
                               #,@==-pfs))))]
 
              ; Contradiction; generate a proof instead of creating a hole
-             [(impossible quodlibet)
-              (values (make-ntt-exact goal (quodlibet (unexpand goal)))
+             [(impossible false-pf)
+              (values (make-ntt-exact #'False false-pf)
                       (λ (pf)
                         #`(λ x ... xrec ... ==-id ...
-                             #,pf)))])])))
+                             (new-elim
+                              #,pf
+                              (λ _ #,(unexpand goal))))))])])))
 
     (make-ntt-apply
      goal

--- a/cur-lib/cur/ntac/inversion.rkt
+++ b/cur-lib/cur/ntac/inversion.rkt
@@ -41,7 +41,7 @@
     ;; irec = indices to recursive args
     (define/syntax-parse
       (elim-TY ([A τA] ...)
-               ([i τi] ...)
+               ([i τi_] ...)
                Cinfo ...)
       (get-match-info name-ty))
 
@@ -62,6 +62,9 @@
       (syntax-parse name-ty
         [((~literal #%plain-app) _ . name-ty-args)
          (stx-split-at #'name-ty-args num-params)]))
+
+    (define/syntax-parse (τi ...)
+      (substs #'(Aval ...) #'(A ...) #'(τi_ ...)))
 
     ; === Generate subgoals for each data constructor case
     ;; subgoals : (listof ntt)
@@ -98,7 +101,7 @@
                          (map syntax->datum (attribute iout))
                          (map syntax->datum (attribute ==-id)))]
 
-           ; Unify provided indices with constructor specific indices, to
+           ; Unify the provided indices (ival) with the constructor's indices (iout)
            (match (prove-unifys (attribute ival)
                                 (attribute iout)
                                 (attribute ==-id))

--- a/cur-lib/cur/ntac/prove-unify.rkt
+++ b/cur-lib/cur/ntac/prove-unify.rkt
@@ -1,0 +1,144 @@
+#lang s-exp "../main.rkt"
+(provide
+ (for-syntax
+  prove-unify
+  prove-unifys
+  derived
+  impossible))
+
+(require
+ (only-in "../stdlib/prop.rkt" True I)
+ "../stdlib/sugar.rkt"
+ "../stdlib/equality.rkt"
+ "../stdlib/nat.rkt"
+ "base.rkt"
+ "standard.rkt"
+ (for-syntax "utils.rkt"
+             ; (only-in macrotypes/typecheck-core subst substs)
+             macrotypes/stx-utils
+             ;racket/list
+             racket/match
+             racket/pretty
+             syntax/stx))
+
+(begin-for-syntax
+
+  ;; ==s    : (listof type-stx)
+  ;; proofs : (listof term-stx)
+  ; Each term proves the corresponding equality type
+  (struct derived [==s proofs])
+
+  ;; quodlibet : type-stx -> term-stx
+  ; 'quodlibet' takes a goal type and returns a proof of that type
+  (struct impossible [quodlibet])
+
+  ;; term-stx term-stx term-stx -> (or/c derived? impossible?)
+  ; Either returns (derived ..) containing equality proofs for subexpressions, or
+  ;   returns (impossible ..) if unification is impossible.
+  ; NOTE: 'top-L' and 'top-R' must be terms of the same type.
+  ;       'top-pf' must be a proof of '(== top-L top-R)'
+  (define (prove-unify top-L top-R top-pf)
+    (let/ec
+        ; Escape cont allows us to immediately exit when we find a contradiction
+        abort
+
+      (define top-TY (typeof top-L))
+      (define top-id (generate-temporary 'x))
+      (define contra-id (generate-temporary 'y))
+
+      (define (mk-proof tgt-TY tgt-term)
+        (if (eq? tgt-TY top-TY)
+          top-pf ; no proof needed
+          #`(f-equal #,(unexpand top-TY)
+                     #,(unexpand tgt-TY)
+                     (λ #,top-id #,tgt-term)
+                     #,(unexpand top-L)
+                     #,(unexpand top-R)
+                     #,top-pf)))
+
+      (define (abort-impossible mk-c)
+        (abort (impossible mk-c)))
+
+      (define ==s    '())
+      (define proofs '())
+
+      ; === Imperatively traverse L and R, looking for new assumptions or contradictions.
+      ; Populates:
+      ;   ==s     (list of equality types found)
+      ;   proofs  (list of proofs of corresponding =='s)
+      (let TRAV ([TY top-TY]
+                 [L top-L]
+                 [R top-R]
+                 ; 'term' is a term of type type 'TY' that satisfies the f-equal proof in
+                 ; 'mk-proof'.
+                 [term top-id])
+        (syntax-parse {list L R}
+          [{({~literal #%plain-app} CL:id L* ...)
+            ({~literal #%plain-app} CR:id R* ...)}
+           #:when (has-type-info? TY)
+           #:with (_ ([A _] ...) _ {~and Cinfo (C _ _)} ...) (get-match-info TY)
+
+           ; === If constructors differ, build a contradiction
+           (unless (and (free-identifier=? #'CL #'CR)
+                        (stx-length=? #'(L* ...) #'(R* ...)))
+             (abort-impossible
+              (λ (goal)
+                (define (mk-match-clause Cinfo)
+                  (syntax-parse Cinfo
+                    [[C ([x _] ... _) _]
+                     #`[(C x ...)
+                        #,(if (stx-datum-equal? #'C #'CL)
+                            #'True
+                            goal)]]))
+                #`(elim-==
+                   #,(mk-proof TY term)
+                   (λ #,contra-id _
+                      (match #,contra-id
+                        #:return Type
+                        #,@(stx-map mk-match-clause #'(Cinfo ...))))
+                   I))))
+
+           ; === Constructors match; recur into subexpressions
+           (for ([i (in-naturals)]
+                 [L* (in-list (stx-drop #'(L* ...) (stx-length #'(A ...))))]
+                 [R* (in-list (stx-drop #'(R* ...) (stx-length #'(A ...))))])
+             (define TY* (typeof L*))
+             (define (mk-match-clause Cinfo)
+               (syntax-parse Cinfo
+                 [[C ([x _] ... _) _]
+                  #`[(C x ...)
+                     #,(if (stx-datum-equal? #'C #'CL)
+                         (stx-list-ref #'(x ...) i)
+                         (unexpand L*))]]))
+             (TRAV TY* L* R*
+                   #`(match #,term
+                       #:return #,(unexpand TY*)
+                       #,@(stx-map mk-match-clause #'(Cinfo ...)))))]
+
+          [_
+           ; === Can't traverse terms any further, so emit a proof now
+           (define tgt-== #`(== #,(unexpand TY) #,(unexpand L) #,(unexpand R)))
+           (define tgt-proof (mk-proof TY term))
+           (set! ==s    (cons tgt-== ==s))
+           (set! proofs (cons tgt-proof proofs))]))
+
+      ; -- finished with TRAV, return the proofs --
+      (derived ==s proofs)))
+
+  (define (prove-unifys Ls Rs pfs)
+    (define-values [==s derived-pfs imposs]
+      (for/fold ([==s '()] [pfs '()] [abort? #f])
+                ([L (in-list Ls)]
+                 [R (in-list Rs)]
+                 [pf (in-list pfs)]
+                 #:break abort?)
+        (match (prove-unify L R pf)
+          [(derived ==s* pfs*)
+           (values (append ==s* ==s)
+                   (append pfs* pfs)
+                   #f)]
+          [(and im (impossible q))
+           (values #f #f im)])))
+    (or imposs (derived ==s derived-pfs)))
+
+  )

--- a/cur-test/cur/tests/ntac/inversion.rkt
+++ b/cur-test/cur/tests/ntac/inversion.rkt
@@ -5,7 +5,8 @@
          cur/stdlib/prop
          cur/ntac/base
          cur/ntac/standard
-         cur/ntac/rewrite
+         (except-in cur/ntac/rewrite by-inversion)
+         cur/ntac/inversion
          rackunit/turnstile
          "rackunit-ntac.rkt")
 
@@ -111,8 +112,7 @@
 (define-theorem one-neq-zero
   (-> (== Nat (s 0) 0) False)
   (by-intro H)
-  (by-inversion H)
-  by-assumption)
+  (by-inversion H))
 
 (check-type one-neq-zero : (-> (== Nat (s 0) 0) False))
 
@@ -188,16 +188,14 @@
 (define-theorem zero-neq-one
   (-> (== Nat 0 (s 0)) False)
   (by-intro H)
-  (by-inversion H)
-  by-assumption)
+  (by-inversion H))
 
 (check-type zero-neq-one : (-> (== Nat 0 (s 0)) False))
 
 (define-theorem zero-neq-two
   (-> (== Nat 0 2) False)
   (by-intro H)
-  (by-inversion H)
-  by-assumption)
+  (by-inversion H))
 
 (check-type zero-neq-two : (-> (== Nat 0 2) False))
 
@@ -206,10 +204,20 @@
  (-> (== Nat (s 0) 0)
      (== Nat (s (s 0)) (s (s (s 0)))))
  (by-intro H)
- (by-inversion H)
  elim-False
- by-assumption)
+ (by-inversion H))
 
 (check-type two-neq-three
+ : (-> (== Nat (s 0) 0)
+     (== Nat (s (s 0)) (s (s (s 0))))))
+
+;; new: eliminates cases, even if goal isn't False
+(define-theorem two-neq-four
+ (-> (== Nat (s 0) 0)
+     (== Nat (s (s 0)) (s (s (s 0)))))
+  (by-intro H)
+  (by-inversion H))
+
+(check-type two-neq-four
  : (-> (== Nat (s 0) 0)
      (== Nat (s (s 0)) (s (s (s 0))))))

--- a/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
@@ -101,7 +101,7 @@
 (define-theorem ev-minus2
   (∀ [n : nat] (-> (ev n) (ev (pred (pred n)))))
   (by-intros n E)
-  (by-inversion* E #:as [(Heq) (n1 E1 Heq)])
+  (by-inversion E #:as [(Heq) (n1 E1 Heq)])
   ;; subgoal 1
   (by-rewriteL Heq)
   (by-apply ev0)
@@ -161,19 +161,19 @@
 (check-type ev-minus2/destruct
   : (forall [n : nat] (-> (ev n) (ev (pred (pred n))))))
 
-(define-theorem true-isnt-false/inversion* (Not (== true false))
+(define-theorem true-isnt-false/inversion (Not (== true false))
  (by-intro H)
- (by-inversion* H))
+ (by-inversion H))
 
-(define-theorem not-ev-3/inversion* (Not (ev 3))
+(define-theorem not-ev-3/inversion (Not (ev 3))
   (by-intros E)
-  (by-inversion* E #:as [() (n1 E1 Heq)])
+  (by-inversion E #:as [() (n1 E1 Heq)])
   ; TODO: automatically rewrite Heq into context
   ; or at least, support (by-rewrite ... #:in H)
   (by-assert H (ev 1))
   (by-rewriteL Heq)
   (by-apply E1)
-  (by-inversion* H))
+  (by-inversion H))
 
 ;; test more than 1 index
 (define-datatype le : [n : nat] [m : nat] -> Prop

--- a/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
@@ -181,6 +181,10 @@
   by-assumption       ; this works now
   )
 
+(define-theorem true-isnt-false/inversion* (Not (== true false))
+ (by-intro H)
+ (by-inversion* H))
+
 (define-theorem not-ev-3/inversion* (Not (ev 3))
   (by-intros E)
   (by-inversion* E #:as [() (n1 E1 Heq)])

--- a/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
@@ -98,13 +98,16 @@
   (by-apply evSS) ;2
   (by-apply IH))
 
-;; TODO: support inversion of arbitrary datatypes
-#;(define-theorem ev-minus2
-  (forall [n : nat] (-> (ev n) (ev (pred (pred n)))))
+(define-theorem ev-minus2
+  (∀ [n : nat] (-> (ev n) (ev (pred (pred n)))))
   (by-intros n E)
-  (by-inversion E #:as [() (n1 E1)])
-  (by-apply ev0) ;1
-  (by-apply E1)) ;2
+  (by-inversion* E #:as [(Heq) (n1 E1 Heq)])
+  ;; subgoal 1
+  (by-rewriteL Heq)
+  (by-apply ev0)
+  ;; subgoal 2
+  (by-rewriteL Heq)
+  (by-apply E1))
 
 ;; ev-minus2 raw term:
 
@@ -158,29 +161,6 @@
 (check-type ev-minus2/destruct
   : (forall [n : nat] (-> (ev n) (ev (pred (pred n))))))
 
-(define-theorem ev-minus2/inversion*/working
-  (∀ [n : nat] (-> (ev n) (ev (pred (pred n)))))
-  (by-intros n E)
-  (by-inversion* E #:as [(Heqi) (n1 E1 Heqi)])
-  ;; subgoal 1
-  (by-rewrite Heqi)
-  (by-apply ev0)
-  ;; subgoal 2
-  (by-rewrite Heqi)
-  (by-apply E1))
-
-(define-theorem ev-minus2/inversion*/assumption
-  (∀ [n : nat] (-> (ev n) (ev (pred (pred n)))))
-  (by-intros n E)
-  (by-inversion* E) ; <- no "#:as"
-  ;; subgoal 1
-  (by-rewrite Heq84)
-  (by-apply ev0)
-  ;; subgoal 2
-  (by-rewrite Heq90)
-  by-assumption       ; this works now
-  )
-
 (define-theorem true-isnt-false/inversion* (Not (== true false))
  (by-intro H)
  (by-inversion* H))
@@ -191,7 +171,7 @@
   ; TODO: automatically rewrite Heq into context
   ; or at least, support (by-rewrite ... #:in H)
   (by-assert H (ev 1))
-  (by-rewrite Heq)
+  (by-rewriteL Heq)
   (by-apply E1)
   (by-inversion* H))
 
@@ -209,7 +189,7 @@
   (by-apply le-S)
   (by-apply le-S)
   (by-apply le-S)
-  (by-apply le-n))  
+  (by-apply le-n))
 
 ;; le-trans raw term
 (check-type

--- a/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
@@ -5,6 +5,7 @@
          cur/ntac/base
          cur/ntac/standard
          cur/ntac/rewrite
+         cur/ntac/inversion
          rackunit/turnstile
          "../rackunit-ntac.rkt")
 
@@ -156,6 +157,29 @@
 
 (check-type ev-minus2/destruct
   : (forall [n : nat] (-> (ev n) (ev (pred (pred n))))))
+
+(define-theorem ev-minus2/inversion*/working
+  (∀ [n : nat] (-> (ev n) (ev (pred (pred n)))))
+  (by-intros n E)
+  (by-inversion* E #:as [() (n1 E1)])
+  ;; subgoal 1
+  (by-rewrite Heqi)
+  (by-apply ev0)
+  ;; subgoal 2
+  (by-rewrite Heqi)
+  (by-apply E1))
+
+#;
+(define-theorem ev-minus2/inversion*/weird-bug
+  (∀ [n : nat] (-> (ev n) (ev (pred (pred n)))))
+  (by-intros n E)
+  (by-inversion* E) ; <- no "#:as"
+  ;; subgoal 1
+  (by-rewrite Heqi)
+  (by-apply ev0)
+  ;; subgoal 2
+  (by-rewrite Heqi)
+  by-assumption)
 
 ;; test more than 1 index
 (define-datatype le : [n : nat] [m : nat] -> Prop

--- a/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
@@ -4,7 +4,7 @@
          cur/stdlib/prop
          cur/ntac/base
          cur/ntac/standard
-         cur/ntac/rewrite
+         (except-in cur/ntac/rewrite by-inversion)
          cur/ntac/inversion
          rackunit/turnstile
          "../rackunit-ntac.rkt")

--- a/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/IndProp.rkt
@@ -161,7 +161,7 @@
 (define-theorem ev-minus2/inversion*/working
   (∀ [n : nat] (-> (ev n) (ev (pred (pred n)))))
   (by-intros n E)
-  (by-inversion* E #:as [() (n1 E1)])
+  (by-inversion* E #:as [(Heqi) (n1 E1 Heqi)])
   ;; subgoal 1
   (by-rewrite Heqi)
   (by-apply ev0)
@@ -169,17 +169,27 @@
   (by-rewrite Heqi)
   (by-apply E1))
 
-#;
-(define-theorem ev-minus2/inversion*/weird-bug
+(define-theorem ev-minus2/inversion*/assumption
   (∀ [n : nat] (-> (ev n) (ev (pred (pred n)))))
   (by-intros n E)
   (by-inversion* E) ; <- no "#:as"
   ;; subgoal 1
-  (by-rewrite Heqi)
+  (by-rewrite Heq84)
   (by-apply ev0)
   ;; subgoal 2
-  (by-rewrite Heqi)
-  by-assumption)
+  (by-rewrite Heq90)
+  by-assumption       ; this works now
+  )
+
+(define-theorem not-ev-3/inversion* (Not (ev 3))
+  (by-intros E)
+  (by-inversion* E #:as [() (n1 E1 Heq)])
+  ; TODO: automatically rewrite Heq into context
+  ; or at least, support (by-rewrite ... #:in H)
+  (by-assert H (ev 1))
+  (by-rewrite Heq)
+  (by-apply E1)
+  (by-inversion* H))
 
 ;; test more than 1 index
 (define-datatype le : [n : nat] [m : nat] -> Prop

--- a/cur-test/cur/tests/ntac/software-foundations/Poly-abbrv.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/Poly-abbrv.rkt
@@ -3,7 +3,8 @@
          cur/stdlib/equality
          cur/ntac/base
          cur/ntac/standard
-         cur/ntac/rewrite
+         (except-in cur/ntac/rewrite by-inversion)
+         cur/ntac/inversion
          "../rackunit-ntac.rkt"
          rackunit/turnstile)
 
@@ -65,12 +66,10 @@
   (by-destruct n)
   ;; destruct 2a: z -----
   (by-inversion H45)
-  elim-False
-  (by-assumption)
   ;; destruct 2b: (s n-1) -----
   (by-apply IH43)
-  (by-inversion H45) ; adds H49
-  (by-rewrite H49)
+  (by-inversion H45) ; adds Heq52
+  (by-rewrite Heq52)
   reflexivity)
 
 (check-type length-app-sym/abbrv

--- a/cur-test/cur/tests/ntac/software-foundations/Poly.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/Poly.rkt
@@ -3,7 +3,8 @@
          cur/stdlib/equality
          cur/ntac/base
          cur/ntac/standard
-         cur/ntac/rewrite
+         (except-in cur/ntac/rewrite by-inversion)
+         cur/ntac/inversion
          "Basics.rkt"
          rackunit/turnstile
          "../rackunit-ntac.rkt")
@@ -130,8 +131,6 @@
   (by-destruct n #:as [() (n-1)])
   ;; destruct 2a: z -----
   (by-inversion H)
-  elim-False
-  (by-assumption)
   ;; destruct 2b: (s n-1) -----
   (by-apply IH)
   (by-inversion H #:as H0)
@@ -204,8 +203,6 @@
   ; destruct 2a
   ; simpl
   (by-inversion H)
-  elim-False
-  by-assumption
   ; destruct 2b
   (by-inversion H #:as H1)
   (by-apply eq-remove-S)
@@ -294,7 +291,7 @@
           (rev (app l (cons n nil))))))
 
 ;; application of cons-rev
-(check-type 
+(check-type
  (λ (X : Type) (x : X) (xs : (list X))
     (cons-rev X (rev_ X xs) x))
  : (∀ [X : Type] [x : X] [xs : (list X)]

--- a/cur-test/cur/tests/ntac/software-foundations/Tactics-destruct.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/Tactics-destruct.rkt
@@ -3,7 +3,8 @@
          cur/stdlib/equality
          cur/ntac/base
          cur/ntac/standard
-         cur/ntac/rewrite
+         (except-in cur/ntac/rewrite by-inversion)
+         cur/ntac/inversion
          rackunit/turnstile
          "../rackunit-ntac.rkt")
 
@@ -189,13 +190,9 @@
   (by-destruct l2 #:as [() (h2 tl2)])
   reflexivity ;1a
   (by-inversion H) ;1b
-  elim-False
-  by-assumption
   (by-intros l2 H) ;2
   (by-destruct l2 #:as [() (h2 tl2)])
   (by-inversion H) ;2a
-  elim-False
-  by-assumption
   (by-inversion H #:as H1);2b
   (by-apply IH #:in H1)
   (by-rewrite H1)

--- a/cur-test/cur/tests/ntac/software-foundations/Tactics-inversion.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/Tactics-inversion.rkt
@@ -3,7 +3,8 @@
          cur/stdlib/equality
          cur/ntac/base
          cur/ntac/standard
-         cur/ntac/rewrite
+         (except-in cur/ntac/rewrite by-inversion)
+         cur/ntac/inversion
          rackunit/turnstile
          "../rackunit-ntac.rkt")
 
@@ -81,7 +82,7 @@
           ((nil*) 0)
           ((cons* g17 g18) g17)))
   (cons* nat 1 (nil* nat))
-  (cons* nat 1 (nil* nat)) 
+  (cons* nat 1 (nil* nat))
   (refl (list nat) (lst 1)))
  : (== 1 1))
 
@@ -209,7 +210,7 @@
   (by-intros n H)
   (by-destruct n #:as [() (n-1)])
   reflexivity ; 1
-  (by-discriminate H)) ; 2
+  (by-inversion H)) ; 2
 
 (check-type beq-nat-0l
  :  (forall [n : nat]
@@ -225,17 +226,13 @@
           (-> (== (S n) O)
               (== (plus 2 2) 5)))
   (by-intros n H)
-  (by-inversion H)
-  elim-False
-  by-assumption)
+  (by-inversion H))
 
 (define-theorem inversion-ex5
   (forall (n m : nat)
           (-> (== false true) (== (lst n) (lst m))))
   (by-intros n m H)
-  (by-inversion H)
-  elim-False
-  by-assumption)
+  (by-inversion H))
 
 ;; generates False proof term for lists
 (define-theorem inversion-ex6
@@ -246,6 +243,4 @@
               (== (:: y l) (:: z j))
               (== x z)))
   (by-intros X x y z l j H1 H2)
-  (by-inversion H1)
-  elim-False
-  by-assumption)
+  (by-inversion H1))

--- a/cur-test/cur/tests/ntac/software-foundations/Tactics3.rkt
+++ b/cur-test/cur/tests/ntac/software-foundations/Tactics3.rkt
@@ -3,7 +3,8 @@
          cur/stdlib/equality
          cur/ntac/base
          cur/ntac/standard
-         cur/ntac/rewrite
+         (except-in cur/ntac/rewrite by-inversion)
+         cur/ntac/inversion
          rackunit/turnstile
          "../rackunit-ntac.rkt")
 
@@ -89,13 +90,9 @@
   (by-destruct m #:as [() (m-1)])
   reflexivity ; 1a
   (by-inversion H #:as H1) ; 1b
-  elim-False
-  by-assumption
   (by-intros m H) ; 2
   (by-destruct m #:as [() (m-1)])
   (by-inversion H #:as H1) ; 2a
-  elim-False
-  by-assumption
   (by-apply f-equal #:with nat nat S n-1 m-1) ; 2b ; unify doesnt find f-equal's A arg
   (by-apply IH)
   (by-inversion H #:as H2)
@@ -117,13 +114,9 @@
   (by-destruct m #:as [() (m-1)])
   reflexivity ; 1a
   (by-inversion H) ; 1b
-  elim-False
-  by-assumption
   (by-intros m H) ; 2
   (by-destruct m #:as [() (m-1)])
   (by-inversion H) ; 2a
-  elim-False
-  by-assumption
   (by-apply f-equal #:with nat nat S n-1 m-1) ; 2b
   (by-apply IH)
   (by-inversion H #:as H1)
@@ -141,13 +134,9 @@
   (by-destruct n #:as [() (n-1)])
   reflexivity ; 1a
   (by-inversion H) ; 1b
-  elim-False
-  by-assumption
   (by-intros n H) ; 2
   (by-destruct n #:as [() (n-1)])
   (by-inversion H) ; 2a
-  elim-False
-  by-assumption
   (by-apply f-equal #:with nat nat S n-1 m-1) ; 2b
   (by-apply IH)
   (by-inversion H #:as H1)
@@ -172,4 +161,4 @@
   (by-apply beq-nat-true) ; prove m = n
   (by-apply H)
   (by-rewrite H1) ; return to orig goal
-  reflexivity) 
+  reflexivity)


### PR DESCRIPTION
Tests affected:
- `cur-test/cur/tests/ntac/inversion.rkt`
- `cur-test/cur/tests/ntac/software-foundations/IndProp.rkt`
- `cur-test/cur/tests/ntac/software-foundations/Poly-abbrv.rkt`
- `cur-test/cur/tests/ntac/software-foundations/Poly.rkt`
- `cur-test/cur/tests/ntac/software-foundations/Tactics-destruct.rkt`
- `cur-test/cur/tests/ntac/software-foundations/Tactics-inversion.rkt`
- `cur-test/cur/tests/ntac/software-foundations/Tactics3.rkt `

New files:
- `cur-lib/ntac/inversion.rkt` (exports: `by-inversion`, `inversion`)
- `cur-lib/ntac/prove-unify.rkt` (exports: `prove-unify`, `prove-unifys`, `derived`, `impossible`)